### PR TITLE
Updated way text field is shown

### DIFF
--- a/ui/src/main/java/com/kotcrab/vis/ui/widget/VisTextField.java
+++ b/ui/src/main/java/com/kotcrab/vis/ui/widget/VisTextField.java
@@ -325,7 +325,7 @@ public class VisTextField extends Widget implements Disableable, Focusable, Bord
 				: ((focused && style.focusedBackground != null) ? style.focusedBackground : style.background);
 
 		// vis
-		if (!disabled && clickListener.isOver() && style.backgroundOver != null) background = style.backgroundOver;
+		if (!disabled && clickListener.isOver() && style.backgroundOver != null && !focused) background = style.backgroundOver;
 
 		Color color = getColor();
 		float x = getX();


### PR DESCRIPTION
Fixed text field displaying the "mouse over" state when already focused. 
This causes problems as field is not going to show the focused state until you move the mouse out of the field